### PR TITLE
chore(ci): Change build command from 'bun run build' to 'bun run rebuild'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
 
       - run: bun install
 
-      - run: bun run build
+      - run: bun run rebuild
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
there is no description that needs to be clarified see #2

## Summary by Sourcery

Update the CI build workflow to use the new Bun rebuild command and adjust artifact upload configuration.

CI:
- Change the build job command from using `bun run build` to `bun run rebuild` in the GitHub Actions workflow.
- Remove explicit `retention-days` configuration from the build artifact upload step.